### PR TITLE
chore(cvsb-19660): remove unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17519,12 +17519,6 @@
         }
       }
     },
-    "serverless-dependency-invoke": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/serverless-dependency-invoke/-/serverless-dependency-invoke-0.0.9.tgz",
-      "integrity": "sha512-5CYGhK3/RIdMshYahXqboOVniO2rYxT0fW3SGuKqplAN7IOwMGXiYSksAovSw0dvZsjMy1j00B6QIGWnedQRNw==",
-      "dev": true
-    },
     "serverless-offline": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-6.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "lambda-tester": "^3.5.0",
     "prettier": "^2.3.2",
     "serverless": "^2.45.2",
-    "serverless-dependency-invoke": "^0.0.9",
     "serverless-offline": "^6.5.0",
     "serverless-plugin-tracing": "^2.0.0",
     "serverless-plugin-typescript": "^1.1.9",


### PR DESCRIPTION
## Remove unused dependency

Removing  serverless-dependency-invoke as it is not used
[link to ticket number](https://jira.dvsacloud.uk/browse/CVSB-19660)

## Checklist

- [x] Branch is rebased against the latest develop
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [x] Link to the PR added to the repo