### PR TITLE
feat(cb2-7789): stop cancelled tests from running updates

### DIFF
--- a/src/functions/updateTechRecord.ts
+++ b/src/functions/updateTechRecord.ts
@@ -15,28 +15,30 @@ export function updateTechRecord(event: SQSEvent) {
 
   event.Records.forEach((record: SQSRecord) => {
     const test = JSON.parse(record.body);
-    console.log("payload recieved from queue:", test);
-    const promiseUpdateStatus =
-      UpdateTechRecordService.updateStatusBySystemNumber(
-        test.systemNumber,
-        test.testStatus,
-        test.testTypes.testResult,
-        test.testTypes.testTypeId,
-        test.newStatus,
-        test.createdById,
-        test.createdByName
-      );
-    if (test.euVehicleCategory) {
-      const promiseUpdateEuCategory =
-        UpdateTechRecordService.updateEuVehicleCategory(
+    console.log("payload received from queue:", test);
+    if (test.testStatus === "submitted") {
+      const promiseUpdateStatus =
+        UpdateTechRecordService.updateStatusBySystemNumber(
           test.systemNumber,
-          test.euVehicleCategory,
+          test.testStatus,
+          test.testTypes.testResult,
+          test.testTypes.testTypeId,
+          test.newStatus,
           test.createdById,
           test.createdByName
         );
-      promisesArray.push(promiseUpdateEuCategory);
+      if (test.euVehicleCategory) {
+        const promiseUpdateEuCategory =
+          UpdateTechRecordService.updateEuVehicleCategory(
+            test.systemNumber,
+            test.euVehicleCategory,
+            test.createdById,
+            test.createdByName
+          );
+        promisesArray.push(promiseUpdateEuCategory);
+      }
+      promisesArray.push(promiseUpdateStatus);
     }
-    promisesArray.push(promiseUpdateStatus);
   });
 
   return Promise.all(promisesArray)


### PR DESCRIPTION
We need to remove broken certs that have now been cancelled.
[https://dvsa.atlassian.net/browse/CB2-7789](https://github.com/dvsa/cvs-tsk-cert-gen-init/pull/7789)